### PR TITLE
New Portal Mechanics: Preserve Momentum and Player direction when usi…

### DIFF
--- a/src/main/java/network/warzone/tgm/modules/portal/Portal.java
+++ b/src/main/java/network/warzone/tgm/modules/portal/Portal.java
@@ -1,5 +1,6 @@
 package network.warzone.tgm.modules.portal;
 
+import io.papermc.paper.entity.TeleportFlag;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 
 @AllArgsConstructor
 public class Portal implements Listener {
@@ -58,15 +60,30 @@ public class Portal implements Listener {
         ABSOLUTE {
             @Override
             public void teleport(Player player, Location location) {
-                player.teleport(location);
+                player.teleportAsync(location);
             }
-        }, RELATIVE {
+        }, RELATIVE_ANGLE {
             @Override
             public void teleport(Player player, Location location) {
-                Location newLocation = player.getLocation().clone().add(location);
-                newLocation.setYaw(newLocation.getYaw() + location.getYaw());
-                newLocation.setPitch(newLocation.getPitch() + location.getPitch());
-                player.teleport(newLocation);
+                location.setYaw(player.getLocation().getYaw());
+                location.setPitch(player.getLocation().getPitch());
+                player.teleportAsync(location);
+            }
+        }, RELATIVE_ANGLE_AND_VELOCITY {
+            @Override
+            public void teleport(Player player, Location location) {
+                location.setYaw(player.getLocation().getYaw());
+                location.setPitch(player.getLocation().getPitch());
+//                Relative location and angle teleport:
+//                Location newLocation = player.getLocation().clone().add(location);
+//                newLocation.setYaw(newLocation.getYaw() + location.getYaw());
+//                newLocation.setPitch(newLocation.getPitch() + location.getPitch());
+//                player.teleportAsync(newLocation);
+                player.teleportAsync(location,
+                    PlayerTeleportEvent.TeleportCause.PLUGIN,
+                    TeleportFlag.Relative.X,
+                    TeleportFlag.Relative.Y,
+                    TeleportFlag.Relative.Z);
             }
         };
 

--- a/src/main/java/network/warzone/tgm/modules/portal/PortalManagerModule.java
+++ b/src/main/java/network/warzone/tgm/modules/portal/PortalManagerModule.java
@@ -52,7 +52,7 @@ public class PortalManagerModule extends MatchModule {
                 active = json.get("active").getAsBoolean();
             }
 
-            Portal.Type type = Portal.Type.ABSOLUTE;
+            Portal.Type type = Portal.Type.RELATIVE_ANGLE_AND_VELOCITY;
             if (json.has("type")) {
                 type = Portal.Type.valueOf(Strings.getTechnicalName(json.get("type").getAsString()));
             }


### PR DESCRIPTION
* Portals by default will now preserve velocity and angle (pitch and yaw)
* Change default portal type to RELATIVE - portals will preserve the direction players are facing. Map creators can add "type": "ABSOLUTE" if they would like players to face a fixed direction in the properties for their portals in map.json or "RELATIVE_ANGLE" if they wish to remove velocity but preserve the direction a player is facing. This feature is currently undocumented but will be documented as of the next docs update.
* Change default portal teleport to use teleportAsync(). This will prevent unncessarily attempting to load chunks that are already loaded. In the incredibly unlikely case you are designing a map that will see portals teleport players into unloaded chunks this may break your map. Please contact us for assistance in working around this issue or updating TGM to support your use case.

Note that the "type" setting is intended to be a temporary workaround. Current portal Map API effect 0 maps currently in rotation and the entire pool. Changes made to portals in the map API are UNSTABLE and will be reworked to allow configuration relative/absolute velocity (in all 3 planes), angle (pitch and yaw) and position on a per-map and per-portal basis.