### PR TITLE
Fix Breaking Monuments in Spectator Post-Death

### DIFF
--- a/src/main/java/club/pvparcade/tgm/modules/dtm/DTMModule.java
+++ b/src/main/java/club/pvparcade/tgm/modules/dtm/DTMModule.java
@@ -2,6 +2,7 @@ package club.pvparcade.tgm.modules.dtm;
 
 import static org.bukkit.SoundCategory.AMBIENT;
 
+import club.pvparcade.tgm.modules.respawn.RespawnModule;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.lang.ref.WeakReference;
@@ -75,7 +76,8 @@ public class DTMModule extends MatchModule implements Listener {
             List<Material> materials = Parser.getMaterialsFromElement(monumentJson.get("materials"));
             int health = monumentJson.get("health").getAsInt();
 
-            this.monuments.add(new Monument(new WeakReference<>(match), name, teams, region, materials, health, health));
+            this.monuments.add(new Monument(new WeakReference<>(match), name, teams, region, materials, health, health, match.getModule(
+                RespawnModule.class)));
             if (materials == null) {
                 continue;
             }

--- a/src/main/java/club/pvparcade/tgm/modules/monument/Monument.java
+++ b/src/main/java/club/pvparcade/tgm/modules/monument/Monument.java
@@ -1,5 +1,6 @@
 package club.pvparcade.tgm.modules.monument;
 
+import club.pvparcade.tgm.modules.respawn.RespawnModule;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +41,8 @@ public class Monument implements Listener {
 
     private final List<MonumentService> services = new ArrayList<>();
 
+    private RespawnModule respawnModule;
+
     @EventHandler(priority = EventPriority.LOWEST)
     public void onBlockBreak(BlockBreakEvent event) {
         if (region.contains(event.getBlock().getLocation())) {
@@ -57,6 +60,12 @@ public class Monument implements Listener {
      */
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBlockBreakHighest(BlockBreakEvent event) {
+        // Prevents players in (survival mode) "spectator" state after death from mining monuments
+        if (respawnModule.isDead(event.getPlayer())) {
+            event.setCancelled(true);
+            return;
+        }
+
         if (region.contains(event.getBlock().getLocation())) {
             if (materials == null || materials.contains(event.getBlock().getType())) {
                 if (canDamage(event.getPlayer())) {


### PR DESCRIPTION
It was possible to be mining a monument, die, and then continue mining when put into spectator state (which is still in survival mode, for movement restriction, visibility restriction, and legacy code support).

It is still possible to trigger this big if the BlockBreakEvent is triggered as the player is respawning and no longer considered dead as soon as they respawn. This could be temporarily patched by adding new APIs to region to get the distance from edge of region to player location when BlockBreakEvent is triggered and if > someConstant, canceling it. Root cause analysis would be preferred and this condition is rare enough that it would be wise to leave it unaddressed from now and work on other issues.